### PR TITLE
October 2021 meeting to dos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # jupyter-communitycalls
 Resources for planning and hosting the Jupyter community calls. Community calls are a place to have fun and celebrate the cool things people do with/in the Jupyter ecosystem and are open to all.
 
-# Next call: October 26 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-10-26/08:00/Jupyter%20Community%20Call))
+# Next call: November 30 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-11-30/08:00/Jupyter%20Community%20Call))
 
-[![Sign up to present](https://img.shields.io/badge/-Sign%20up%20to%20present-orange)](https://hackmd.io/nqvcqCoKSruLzs3JlVkLNQ)
+[![Sign up to present](https://img.shields.io/badge/-Sign%20up%20to%20present-orange)](https://hackmd.io/_Jc4d-QaT_qQdRp7hREibA?edit)
 
 [![Give feedback](https://img.shields.io/badge/-Give%20feedback-blue)](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 
@@ -23,7 +23,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 [Recorded calls playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
 
 ### For Participants
-[Sign up to present](https://hackmd.io/nqvcqCoKSruLzs3JlVkLNQ)
+[Sign up to present](https://hackmd.io/_Jc4d-QaT_qQdRp7hREibA?edit)
 
 [Give feedback](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 


### PR DESCRIPTION
## October 2021 meeting to dos

<!--Use this PR to change the readme with details for the call two months out. That way when this
to do list is complete and the PR is merged, the readme is ready to go with the correct date and 
links for the upcoming call.-->

Schedule call
- [ ] Add to calendars
- [ ] Make HackMD agenda/notes
- [ ] Schedule host (let different people host)
- [ ] Update agenda on Jupyter community calendar
- [ ] People requested a costume call for October. Remember to advertise that!

Promote call/recruit presenters
- [ ] Post on discourse 2 weeks before
- [ ] Tweet 2 weeks before
- [ ] Post on mailing list 2 weeks before
- [ ] Post to jupyterhub/team-compass 2 weeks before
- [ ] Post on discourse 1 week before
- [ ] Post on mailing list 1 week before

Post-call
- [ ] Download meeting recording
- [ ] Upload meeting recording to youtube 
- [ ] Submit PR for agenda/notes in docs
- [ ] Add youtube and agenda/notes link to discourse page
- [ ] Add youtube and agenda/notes link to jupyterhub/team-compass issue and close it.
- [ ] Tweet youtube link
