### PR TITLE
January 2022 call to dos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # jupyter-communitycalls
 Resources for planning and hosting the Jupyter community calls. Community calls are a place to have fun and celebrate the cool things people do with/in the Jupyter ecosystem and are open to all.
 
-# Next call: January 25 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-01-25/08:00/Jupyter%20Community%20Call))
+# Next call: February 25 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-02-22/08:00/Jupyter%20Community%20Call))
 
-😴 We will be taking a break from community calls in December to give the community time to rest. Join us again in January for a new year of Jupyter excitement!
-
-[![Sign up to present on the agenda](https://img.shields.io/badge/-Sign%20up%20to%20present%20on%20the%20agenda-orange)](https://hackmd.io/YIX3UHIiQFy2Uk3FmQA7XA)
+[![Sign up to present on the agenda](https://img.shields.io/badge/-Sign%20up%20to%20present%20on%20the%20agenda-orange)](https://hackmd.io/_l4C-oh2S7iWIqMGPtNN1w)
 
 [![Join the meeting on Zoom](https://img.shields.io/badge/-Join%20the%20meeting%20on%20Zoom-brightgreen)](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 
@@ -27,7 +25,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 
 ### For Participants
 
-[Sign up to present on the agenda](https://hackmd.io/YIX3UHIiQFy2Uk3FmQA7XA)
+[Sign up to present on the agenda](https://hackmd.io/_l4C-oh2S7iWIqMGPtNN1w)
 
 [Give feedback](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 


### PR DESCRIPTION
## January 25, 2022 meeting to dos

<!--Use this PR to change the readme with details for the call two months out. That way when this
to do list is complete and the PR is merged, the readme is ready to go with the correct date and 
links for the upcoming call.-->

Schedule call
- [x] Add to calendars
- [x] Make HackMD agenda/notes
- [x] Schedule host (let different people host)
- [x] Update agenda on Jupyter community calendar

Promote call/recruit presenters
- [x] Post on discourse 2 weeks before
- [x] Tweet 2 weeks before
- [x] Post on mailing list 2 weeks before
- [x] Post to jupyterhub/team-compass 2 weeks before
- [x] Post on discourse 1 week before
- [x] Post on mailing list 1 week before

Post-call
- [x] Download meeting recording
- [x] Upload meeting recording to youtube 
- [x] Submit PR for agenda/notes in docs
- [x] Add youtube and agenda/notes link to discourse page
- [x] Add youtube and agenda/notes link to jupyterhub/team-compass issue and close it.
- [x] Tweet youtube link
