### PR TITLE
March 29, 2022 meeting to dos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyter-communitycalls
 Resources for planning and hosting the Jupyter community calls. Community calls are a place to have fun and celebrate the cool things people do with/in the Jupyter ecosystem and are open to all.
 
-# Next call: April 26 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-04-26/08:00/Jupyter%20Community%20Call))
+# Next call: April 26 at 7am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-04-26/07:00/Jupyter%20Community%20Call))
 
 [![Sign up to present on the agenda](https://img.shields.io/badge/-Sign%20up%20to%20present%20on%20the%20agenda-orange)](https://hackmd.io/87YKY8PRQs6FIlxTKX0mDw)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # jupyter-communitycalls
 Resources for planning and hosting the Jupyter community calls. Community calls are a place to have fun and celebrate the cool things people do with/in the Jupyter ecosystem and are open to all.
 
-# Next call: March 29 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-03-29/08:00/Jupyter%20Community%20Call))
+# Next call: April 26 at 8am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2022-04-26/08:00/Jupyter%20Community%20Call))
 
-[![Sign up to present on the agenda](https://img.shields.io/badge/-Sign%20up%20to%20present%20on%20the%20agenda-orange)](https://hackmd.io/RCQYZWquRY-rxrRsah_GkQ)
+[![Sign up to present on the agenda](https://img.shields.io/badge/-Sign%20up%20to%20present%20on%20the%20agenda-orange)](https://hackmd.io/87YKY8PRQs6FIlxTKX0mDw)
 
 [![Join the meeting on Zoom](https://img.shields.io/badge/-Join%20the%20meeting%20on%20Zoom-brightgreen)](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 
@@ -25,7 +25,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 
 ### For Participants
 
-[Sign up to present on the agenda](https://hackmd.io/RCQYZWquRY-rxrRsah_GkQ)
+[Sign up to present on the agenda](https://hackmd.io/87YKY8PRQs6FIlxTKX0mDw)
 
 [Give feedback](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 


### PR DESCRIPTION
## March 29, 2022 meeting to dos

<!--Use this PR to change the readme with details for the call two months out. That way when this
to do list is complete and the PR is merged, the readme is ready to go with the correct date and 
links for the upcoming call.-->

Schedule call
- [x] Add to calendars
- [x] Make HackMD agenda/notes
- [x] Schedule host (let different people host)
- [x] Update agenda on Jupyter community calendar

Promote call/recruit presenters
- [x] Post on discourse 2 weeks before
- [x] Tweet 2 weeks before
- [x] Post on mailing list 2 weeks before
- [x] Post to jupyterhub/team-compass 2 weeks before
- [ ] Post on discourse 1 week before
- [x] Post on mailing list 1 week before

Post-call
- [x] Download meeting recording
- [x] Upload meeting recording to youtube 
- [x] Submit PR for agenda/notes in docs
- [ ] Add youtube and agenda/notes link to discourse page
- [ ] Add youtube and agenda/notes link to jupyterhub/team-compass issue and close it.
- [ ] Tweet youtube link
