### PR TITLE
Update to dos PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,16 +6,16 @@ links for the upcoming call.-->
 
 ### Scheduling
 
-- [ ] Add to [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings)
-- [ ] Make HackMD agenda/notes ([agenda template](https://github.com/Quansight-Labs/jupyter-communitycalls/blob/main/agenda-template.md))
+- [ ] Add event to the [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings)
+- [ ] Make HackMD agenda/notes ([agenda template](https://github.com/Quansight-Labs/jupyter-communitycalls/blob/main/agenda-template.md)) and check the link permissions allow for public access
 - [ ] Schedule host (let different people host)
-- [ ] Update agenda link on [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings) event
+- [ ] Update agenda link on the [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings) event description
 
 ### Promotion
 
-- [ ] Update [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668) and/or add comment 2 weeks before
+- [ ] Update [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668) and/or add a comment 2 weeks before
 - [ ] Tweet (on personal account, request [Project Jupyter retweet](https://twitter.com/ProjectJupyter/)) 2 weeks before
-- [ ] Post on [Jupyter mailing list](https://groups.google.com/g/jupyter/) 2 weeks before
+- [ ] Post on the [Jupyter mailing list](https://groups.google.com/g/jupyter/) 2 weeks before
 - [ ] Post issue to [jupyterhub/team-compass](https://github.com/jupyterhub/team-compass/) 2 weeks before
 - [ ] Post on [Jupyter Discourse](https://github.com/jupyterhub/team-compass/) 1 week before
 - [ ] Post on [Jupyter mailing list](https://groups.google.com/g/jupyter/) 1 week before
@@ -25,6 +25,6 @@ links for the upcoming call.-->
 - [ ] Download meeting recording
 - [ ] Upload meeting recording to [YouTube channel](https://www.youtube.com/ipython) and add it to the [community call playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
 - [ ] Submit PR for agenda/notes in the [Jupyter community documentation](https://github.com/jupyter/jupyter/)
-- [ ] Add YouTube and agenda/notes link to the [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668)
-- [ ] Add YouTube and agenda/notes link to the [jupyterhub/team-compass](https://github.com/jupyterhub/team-compass/) issue and close it
+- [ ] Add YouTube and agenda/notes links to the [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668)
+- [ ] Add YouTube and agenda/notes links to the [jupyterhub/team-compass](https://github.com/jupyterhub/team-compass/) issue and close it
 - [ ] Tweet YouTube link (on personal account, request [Project Jupyter retweet](https://twitter.com/ProjectJupyter/))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,24 +4,27 @@
 to do list is complete and the PR is merged, the readme is ready to go with the correct date and 
 links for the upcoming call.-->
 
-Schedule call
-- [ ] Add to calendars
-- [ ] Make HackMD agenda/notes
+### Scheduling
+
+- [ ] Add to [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings)
+- [ ] Make HackMD agenda/notes ([agenda template](https://github.com/Quansight-Labs/jupyter-communitycalls/blob/main/agenda-template.md))
 - [ ] Schedule host (let different people host)
-- [ ] Update agenda on Jupyter community calendar
+- [ ] Update agenda link on [Jupyter community calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings) event
 
-Promote call/recruit presenters
-- [ ] Post on discourse 2 weeks before
-- [ ] Tweet 2 weeks before
-- [ ] Post on mailing list 2 weeks before
-- [ ] Post to jupyterhub/team-compass 2 weeks before
-- [ ] Post on discourse 1 week before
-- [ ] Post on mailing list 1 week before
+### Promotion
 
-Post-call
+- [ ] Update [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668) and/or add comment 2 weeks before
+- [ ] Tweet (on personal account, request [Project Jupyter retweet](https://twitter.com/ProjectJupyter/)) 2 weeks before
+- [ ] Post on [Jupyter mailing list](https://groups.google.com/g/jupyter/) 2 weeks before
+- [ ] Post issue to [jupyterhub/team-compass](https://github.com/jupyterhub/team-compass/) 2 weeks before
+- [ ] Post on [Jupyter Discourse](https://github.com/jupyterhub/team-compass/) 1 week before
+- [ ] Post on [Jupyter mailing list](https://groups.google.com/g/jupyter/) 1 week before
+
+### Recording
+
 - [ ] Download meeting recording
-- [ ] Upload meeting recording to youtube 
-- [ ] Submit PR for agenda/notes in docs
-- [ ] Add youtube and agenda/notes link to discourse page
-- [ ] Add youtube and agenda/notes link to jupyterhub/team-compass issue and close it.
-- [ ] Tweet youtube link
+- [ ] Upload meeting recording to [YouTube channel](https://www.youtube.com/ipython) and add it to the [community call playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
+- [ ] Submit PR for agenda/notes in the [Jupyter community documentation](https://github.com/jupyter/jupyter/)
+- [ ] Add YouTube and agenda/notes link to the [Jupyter Discourse wiki](https://discourse.jupyter.org/t/jupyter-community-calls/668)
+- [ ] Add YouTube and agenda/notes link to the [jupyterhub/team-compass](https://github.com/jupyterhub/team-compass/) issue and close it
+- [ ] Tweet YouTube link (on personal account, request [Project Jupyter retweet](https://twitter.com/ProjectJupyter/))


### PR DESCRIPTION
The PR template helps make running meetings easy because it provides a checklist for pre- and post-call to dos. Right now, the template is a little rough around the edges for someone reading it with no other context. This PR adds:

- Links to clarify relevant websites and accounts mentioned
- More specific and complete instructions
- Proper headings

all to the `.github/pull-request-template.md`

I'll be leaving this open so I review with fresh eyes, but I likely will merge it before the January 2023 call. Feel free to review it if someone besides me is reading this. 🌻 